### PR TITLE
Feature/user field rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on: [pull_request]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
+
+    - name: Install project and dev dependencies
+      run: uv sync --frozen --extra dev
+
+    - name: Run unit tests
+      run: uv run python -m unittest discover -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Admin defined merge field rules.
+
 ### Changed
 
 - Updated nginx configuration.
 - Made Memo Label optional for Fjernpost.
+
+### Dev
+
+- Added Github action to run unit tests.
+- Added tests for internal merge field rules functions.
 
 ## [0.2.0]
 

--- a/src/OpenPostbud/database/digital_post/field_rules.py
+++ b/src/OpenPostbud/database/digital_post/field_rules.py
@@ -1,0 +1,150 @@
+"""This module contains the FieldRule ORM class and admin-configurable
+merge field validation rules.
+
+Unlike the hardcoded MemoFields in `letters.py`, these rules are managed by
+admins at runtime and are enforced at send-off (in the shipment worker), not
+during shipment creation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+import re
+
+from sqlalchemy import String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from OpenPostbud.database.base import Base
+from OpenPostbud.database import connection
+from OpenPostbud.database.common import PostType
+
+
+class RuleType(Enum):
+    """The kind of check a FieldRule performs on a field's value.
+
+    NOT_CONTAINS: The field value must not contain the rule value (case-insensitive).
+    REGEX_MATCH: The field value must fully match the rule value as a regex pattern.
+    """
+    NOT_CONTAINS = "Må ikke indeholde"
+    REGEX_MATCH = "Skal matche mønster"
+
+
+class FieldRule(Base):
+    """An ORM class representing an admin-configured merge field rule."""
+    __tablename__ = "FieldRules"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    field_name: Mapped[str] = mapped_column(String(255))
+    rule_type: Mapped[RuleType]
+    value: Mapped[str] = mapped_column(String(500))
+    apply_digital: Mapped[bool] = mapped_column(default=True)
+    apply_physical: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now)
+
+    def applies_to(self, post_type: PostType) -> bool:
+        """Whether this rule should be checked for the given post type.
+
+        AUTO applies the rule if it applies to either route, so the letter is
+        checked whichever route a recipient takes.
+        """
+        if post_type == PostType.DIGITAL:
+            return self.apply_digital
+        if post_type == PostType.PHYSICAL:
+            return self.apply_physical
+        return self.apply_digital or self.apply_physical
+
+    def is_satisfied(self, field_data: dict[str, str]) -> bool:
+        """Whether the given merge data satisfies this rule.
+
+        A rule on a field that is absent from the data is considered satisfied,
+        mirroring the MemoFields pattern matching behavior.
+        """
+        if self.field_name not in field_data:
+            return True
+
+        value = field_data[self.field_name]
+
+        if self.rule_type == RuleType.NOT_CONTAINS:
+            return self.value.lower() not in value.lower()
+        if self.rule_type == RuleType.REGEX_MATCH:
+            return re.fullmatch(self.value, value) is not None
+        return True
+
+    def to_row_dict(self) -> dict[str, str]:
+        """Convert to a dictionary to be shown in a table."""
+        return {
+            "id": self.id,
+            "field_name": self.field_name,
+            "rule_type": self.rule_type.value,
+            "value": self.value,
+            "apply_digital": "Ja" if self.apply_digital else "Nej",
+            "apply_physical": "Ja" if self.apply_physical else "Nej",
+        }
+
+
+def get_field_rules() -> tuple[FieldRule]:
+    """Get all field rules in the database."""
+    with connection.get_session() as session:
+        result = session.execute(select(FieldRule)).scalars()
+        return tuple(result)
+
+
+def create_field_rule(field_name: str, rule_type: RuleType, value: str, apply_digital: bool, apply_physical: bool) -> FieldRule:
+    """Add a new field rule to the database.
+
+    Args:
+        field_name: The name of the merge field column the rule checks.
+        rule_type: The kind of check to perform.
+        value: The substring or regex pattern the check uses.
+        apply_digital: Whether the rule applies to Digital Post.
+        apply_physical: Whether the rule applies to Fysisk Post.
+
+    Returns:
+        The created field rule.
+    """
+    rule = FieldRule(
+        field_name=field_name,
+        rule_type=rule_type,
+        value=value,
+        apply_digital=apply_digital,
+        apply_physical=apply_physical,
+    )
+
+    with connection.get_session() as session:
+        session.add(rule)
+        session.commit()
+
+    return rule
+
+
+def delete_field_rule(rule_id: int) -> bool:
+    """Delete the field rule with the given id.
+
+    Returns:
+        True if a rule was deleted, False if no rule was found.
+    """
+    with connection.get_session() as session:
+        rule = session.get(FieldRule, rule_id)
+        if rule:
+            session.delete(rule)
+            session.commit()
+            return True
+        return False
+
+
+def validate_field_data(field_data: dict[str, str], route: PostType) -> str | None:
+    """Validate merge data against all applicable field rules.
+
+    Args:
+        field_data: The letter's merge data.
+        route: The concrete route the letter is being sent as (DIGITAL or PHYSICAL).
+
+    Returns:
+        A short error message for the first violated rule, or None if all rules pass.
+    """
+    for rule in get_field_rules():
+        if rule.applies_to(route) and not rule.is_satisfied(field_data):
+            # Keep within the Letter.message column limit (100 chars).
+            return f"Regel overtrådt: {rule.field_name} - {rule.rule_type.value}"[:100]
+    return None

--- a/src/OpenPostbud/database/migrations/sql/003_add_field_rules.sql
+++ b/src/OpenPostbud/database/migrations/sql/003_add_field_rules.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "FieldRules" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_name VARCHAR(255) NOT NULL,
+    rule_type VARCHAR(20) NOT NULL,
+    value VARCHAR(500) NOT NULL,
+    apply_digital BOOLEAN NOT NULL DEFAULT 1,
+    apply_physical BOOLEAN NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL
+)

--- a/src/OpenPostbud/routes/admin/field_rules.py
+++ b/src/OpenPostbud/routes/admin/field_rules.py
@@ -1,0 +1,98 @@
+"""This module is responsible for the admin page for merge field rules."""
+
+from nicegui import ui, APIRouter
+
+from OpenPostbud import ui_components
+from OpenPostbud.database.digital_post import field_rules
+from OpenPostbud.database.digital_post.field_rules import RuleType
+
+router = APIRouter()
+
+RULE_COLUMNS = [
+    {'name': "field_name",      'label': "Felt",            'field': "field_name"},
+    {'name': "rule_type",       'label': "Regel",           'field': "rule_type"},
+    {'name': "value",           'label': "Værdi",           'field': "value"},
+    {'name': "apply_digital",   'label': "Digital Post",    'field': "apply_digital"},
+    {'name': "apply_physical",  'label': "Fysisk Post",     'field': "apply_physical"},
+]
+
+COLUMN_DEFAULTS = {'align': 'left', 'sortable': True, 'style': 'padding-right: 5rem'}
+
+
+@router.page("/field-rules", name="Field Rules")
+def field_rules_page():
+    """Show the field rules page."""
+    ui_components.header()
+    FieldRulePage()
+
+
+class FieldRulePage:
+    """A class representing the field rules page."""
+    def __init__(self):
+        ui.label("Feltregler").classes("text-4xl")
+        ui.label(
+            "Her kan du oprette ekstra regler for flettefelter. "
+            "Reglerne tjekkes når posten afsendes."
+        )
+        ui.button("Ny regel", on_click=self._add_rule)
+
+        self.table = ui.table(rows=[], columns=RULE_COLUMNS, column_defaults=COLUMN_DEFAULTS)
+        self.table.on("rowClick", self._row_click)
+        self._update_table()
+
+    def _update_table(self):
+        """Update the rules table with the newest data from the database."""
+        rows = [rule.to_row_dict() for rule in field_rules.get_field_rules()]
+        self.table.rows = rows
+
+    def _row_click(self, event):
+        """Open a dialog for the clicked rule row."""
+        with ui.dialog(value=True) as dialog, ui.card():
+            row = event.args[1]
+            ui.label(f"{row['field_name']} - {row['rule_type']}").classes("text-xl")
+            ui.label(f"Værdi: {row['value']}")
+            with ui.row():
+                ui.button("Slet", on_click=lambda e: self._delete_rule(row['id'], dialog))
+                ui.button("Luk", on_click=dialog.close)
+
+    async def _add_rule(self):
+        """Show a popup to create a new field rule."""
+        with ui.dialog(value=True).props('persistent') as dialog, ui.card():
+            ui.label("Ny feltregel").classes("text-lg")
+            field_name = ui.input("Feltnavn").classes("w-full")
+            rule_type = ui.select({rt: rt.value for rt in RuleType}, label="Regel", value=RuleType.NOT_CONTAINS).classes("w-full")
+            value = ui.input("Værdi").classes("w-full")
+            apply_digital = ui.checkbox("Digital Post", value=True)
+            apply_physical = ui.checkbox("Fysisk Post", value=True)
+            with ui.row():
+                ui.button("Gem", on_click=lambda e: dialog.submit(True))
+                ui.button("Luk", on_click=lambda e: dialog.submit(False)).props("flat")
+
+            if not await dialog:
+                return
+
+        if not field_name.value or not value.value:
+            ui.notify("Udfyld både feltnavn og værdi", type="warning")
+            return
+
+        field_rules.create_field_rule(
+            field_name.value,
+            rule_type.value,
+            value.value,
+            apply_digital.value,
+            apply_physical.value,
+        )
+        ui.notify("Regel oprettet", type="positive")
+        self._update_table()
+
+    async def _delete_rule(self, rule_id: int, dialog: ui.dialog):
+        """Show a confirmation popup and delete the rule with the given id."""
+        if not await ui_components.question_popup("Vil du slette denne regel?", "Ja", "Nej"):
+            return
+
+        if field_rules.delete_field_rule(rule_id):
+            ui.notify("Regel slettet", type='positive')
+            self._update_table()
+            dialog.close()
+        else:
+            ui.notify("Regel ikke fundet", type='negative')

--- a/src/OpenPostbud/routes/admin/router.py
+++ b/src/OpenPostbud/routes/admin/router.py
@@ -5,9 +5,11 @@ That is all routes that require an admin to be logged in.
 from nicegui import APIRouter
 
 from OpenPostbud.routes.admin import api_users
+from OpenPostbud.routes.admin import field_rules
 
 
 # Router object for all admin routes
 router = APIRouter(prefix="/admin", include_in_schema=False)
 
 router.include_router(api_users.router)
+router.include_router(field_rules.router)

--- a/src/OpenPostbud/routes/user/send_post.py
+++ b/src/OpenPostbud/routes/user/send_post.py
@@ -13,7 +13,7 @@ from jinja2.exceptions import TemplateSyntaxError
 
 from OpenPostbud import ui_components
 from OpenPostbud.middleware import authentication
-from OpenPostbud.database.digital_post import letters, shipments, templates
+from OpenPostbud.database.digital_post import letters, shipments, templates, field_rules
 from OpenPostbud.database.digital_post.letters import MemoFields
 from OpenPostbud.database.common import PostType
 from OpenPostbud.utils import docx_util
@@ -58,9 +58,10 @@ class SendPostPage:
                 ui.button("Send Post", on_click=self._send_post)
                 _stepper_navigation(stepper, next_button=False)
 
-        # Re-run csv validation when the post type changes, since the set of
-        # mandatory fields depends on it.
-        self.step1.post_type.on_value_change(lambda: self.step2.refresh_messages())
+        # Re-run csv validation and refresh the field list when the post type
+        # changes, since both the mandatory fields and which custom rules apply
+        # depend on it.
+        self.step1.post_type.on_value_change(self.step2.on_post_type_change)
 
     def _on_csv_data_changed(self, fields: list[str], rows: list[dict[str, str]] | None):
         """Forward csv changes from step 2 to step 3."""
@@ -134,6 +135,10 @@ class FileUploadStep:
         self.template_fields: list[str] = []
         self.csv_data: list[dict[str, str]] | None = None
         self.csv_fields: list[str] = []
+
+        # All custom admin field rules, used to mark fields in the csv field
+        # list that have a rule applicable to the selected post type.
+        self._rules = field_rules.get_field_rules()
 
         with ui.grid(columns=2):
             ui.label("Upload skabelon (.docx, .pdf)").classes("text-bold")
@@ -238,6 +243,13 @@ class FileUploadStep:
                     ui.label(f)
                 ui.separator()
 
+        # Only mark fields whose rules apply to the selected post type.
+        post_type = self._get_post_type()
+        rule_fields: dict[str, list[str]] = {}
+        for rule in self._rules:
+            if rule.applies_to(post_type):
+                rule_fields.setdefault(rule.field_name, []).append(f"{rule.rule_type.value}: {rule.value}")
+
         self.csv_fields_area.clear()
         with self.csv_fields_area:
             for f in self.csv_fields:
@@ -245,9 +257,23 @@ class FileUploadStep:
                     with ui.row(align_items='center'):
                         ui.icon("settings", color='secondary')
                         ui.label(str(f)).classes("text-secondary")
+                elif f in rule_fields:
+                    with ui.row(align_items='center'):
+                        ui.icon("rule", color='secondary')
+                        ui.label(str(f)).classes("text-secondary")
+                        ui.tooltip(" / ".join(rule_fields[f]))
                 else:
                     ui.label(str(f))
                 ui.separator()
+
+    def on_post_type_change(self):
+        """Refresh the field list and messages when the post type changes.
+
+        Both the mandatory fields and which custom rules apply depend on the
+        selected post type.
+        """
+        self._update_field_tables()
+        self.refresh_messages()
 
     def refresh_messages(self):
         """Rebuild the message area from current template + csv state.

--- a/src/OpenPostbud/ui_components.py
+++ b/src/OpenPostbud/ui_components.py
@@ -29,6 +29,8 @@ def header():
         if authentication.is_admin():
             ui.separator().props("vertical color=white size=2px")
             ui.link("API Brugere", app.url_path_for("API Users")).classes(replace='text-lg text-white')
+            ui.separator().props("vertical color=white size=2px")
+            ui.link("Feltregler", app.url_path_for("Field Rules")).classes(replace='text-lg text-white')
 
         ui.space()
         ui.label(authentication.get_current_user()).classes('text-lg text-white')

--- a/src/OpenPostbud/workers/shipment_worker.py
+++ b/src/OpenPostbud/workers/shipment_worker.py
@@ -19,7 +19,7 @@ from requests import Timeout, HTTPError
 from OpenPostbud import config
 from OpenPostbud.database import connection
 from OpenPostbud.database.digital_post.letters import Letter, MemoFields
-from OpenPostbud.database.digital_post import shipments
+from OpenPostbud.database.digital_post import shipments, field_rules
 from OpenPostbud.database.common import ShipmentStatus, PostType
 
 
@@ -121,10 +121,18 @@ def send_letter(letter: Letter, kombit_access: KombitAccess):
 
 def send_digital(letter: Letter, kombit_access: KombitAccess):
     """Send a letter as Digital Post."""
+    field_data = json.loads(letter.field_data)
+
+    error = field_rules.validate_field_data(field_data, PostType.DIGITAL)
+    if error:
+        letter.set_status(ShipmentStatus.FAILED, message=error)
+        logging.info(f"Letter {letter.id} failed field rule: {error}")
+        return
+
     document = letter.merge_letter()
     b64_doc = base64.b64encode(document).decode()
 
-    label = json.loads(letter.field_data)[MemoFields.MEMO_LABEL.key]
+    label = field_data[MemoFields.MEMO_LABEL.key]
 
     message_uuid = str(uuid.uuid4())
 
@@ -172,6 +180,12 @@ def send_physical(letter: Letter, kombit_access: KombitAccess):
     The recipient address must be present in the letter itself so it shows
     through the window of the envelope. The recipient id is therefore not sent.
     """
+    error = field_rules.validate_field_data(json.loads(letter.field_data), PostType.PHYSICAL)
+    if error:
+        letter.set_status(ShipmentStatus.FAILED, message=error)
+        logging.info(f"Letter {letter.id} failed field rule: {error}")
+        return
+
     document = letter.merge_letter()
 
     forsendelse = create_physical_mail(config.PHYSICAL_MAIL_FORSENDELSE_TYPE, document)

--- a/test_data/Merge_data physical.csv
+++ b/test_data/Merge_data physical.csv
@@ -1,6 +1,6 @@
-Memo Modtager,Name,Noun
-2611740000,John,man
-2611740000,Isabella,woman
-2611740000,Spot,dog
-2611740001,Fail,Failure
-12345678,Firma,Company
+Memo Modtager,Name,Noun,postnummer
+2611740000,John,man,1234
+2611740000,Isabella,woman,1234
+2611740000,Spot,dog,1234
+2611740001,Fail,Failure,0000
+12345678,Firma,Company,1234

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,68 @@
-"""Unit tests for OpenPostbud."""
+"""Unit tests for OpenPostbud.
+
+Importing this package prepares a minimal fake configuration environment so the
+application modules can be imported without a real .env file present (e.g. in
+CI). OpenPostbud.config loads settings from a .env file on import, and
+encrypted_string.py builds a Fernet cipher from database_storage_secret at
+import time, so a valid key must be available.
+"""
+
+import atexit
+import os
+import tempfile
+
+from cryptography.fernet import Fernet
+
+
+def _prepare_test_environment():
+    """Populate env vars and placeholder files so OpenPostbud.config can be
+    imported without a real .env file.
+
+    Values are set with setdefault and an empty .env placeholder is only created
+    when one is absent, so a developer's real .env is left untouched.
+    """
+    test_env = {
+        "nicegui_storage_secret": "test-secret",
+        # Must be a valid Fernet key; a cipher is built from it on import.
+        "database_storage_secret": Fernet.generate_key().decode(),
+        "auth_lifetime_seconds": "43200",
+        "shipment_lifetime_days": "30",
+        "registration_job_lifetime_days": "14",
+        "api_jwt_secret": "test-secret",
+        "api_token_lifetime_seconds": "3600",
+        "cvr": "12345678",
+        "Kombit_test_env": "True",
+        "registration_worker_sleep_time": "10",
+        "shipment_worker_sleep_time": "10",
+        "sender_label": "Test",
+        "physical_mail_forsendelse_type": "12345",
+        "message_broker_queue_id": "00000000-0000-0000-0000-000000000000",
+        "message_broker_worker_sleep_time": "60",
+        "client_id": "test-client",
+        "client_secret": "test-secret",
+        "discovery_url": "https://example.test/.well-known/openid-configuration",
+        "redirect_url": "https://example.test/auth/callback",
+        "jwt_leeway": "60",
+        "admin_role_name": "Administrator",
+        "user_role_name": "User",
+    }
+
+    # config validates that kombit_cert_path points to an existing file.
+    cert_fd, cert_path = tempfile.mkstemp(prefix="test_cert_", suffix=".pem")
+    os.close(cert_fd)
+    atexit.register(os.unlink, cert_path)
+    test_env["kombit_cert_path"] = cert_path
+
+    for key, value in test_env.items():
+        os.environ.setdefault(key, value)
+
+    # config requires a .env file to exist (read with override=True). When one is
+    # absent (e.g. in CI), create an empty placeholder so the os.environ values
+    # above are used as-is.
+    if not os.path.isfile(".env"):
+        with open(".env", "w", encoding="utf-8"):
+            pass
+        atexit.register(os.unlink, ".env")
+
+
+_prepare_test_environment()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for OpenPostbud."""

--- a/tests/db_test_case.py
+++ b/tests/db_test_case.py
@@ -1,0 +1,40 @@
+"""Reusable unittest base class providing an isolated in-memory database."""
+
+import unittest
+from unittest import mock
+
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from OpenPostbud.database import connection
+
+
+class DatabaseTestCase(unittest.TestCase):
+    """Base test case that swaps the application database for an isolated
+    in-memory SQLite database.
+
+    The connection engine is patched with an in-memory engine, so tests never
+    touch the application database. StaticPool keeps a single underlying
+    connection alive so the schema and data persist across the separate
+    sessions opened by the code under test.
+
+    All ORM tables registered on the metadata (i.e. whose modules have been
+    imported) are created, so subclasses only need to import the models they
+    exercise.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+        # Patch before creating tables so create_tables uses the in-memory engine.
+        patcher = mock.patch.object(connection, "get_connection_engine", return_value=self.engine)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        self.addCleanup(self.engine.dispose)
+
+        connection.create_tables()

--- a/tests/test_field_rules.py
+++ b/tests/test_field_rules.py
@@ -1,0 +1,222 @@
+"""Unit tests for the admin-configurable merge field rules."""
+
+import unittest
+from unittest import mock
+
+from OpenPostbud.database.common import PostType
+from OpenPostbud.database.digital_post import field_rules
+from OpenPostbud.database.digital_post.field_rules import FieldRule, RuleType
+
+from tests.db_test_case import DatabaseTestCase
+
+
+def _rule(field_name="Testfelt", rule_type=RuleType.NOT_CONTAINS, value="forbudt",
+          apply_digital=True, apply_physical=True) -> FieldRule:
+    """Build a FieldRule instance for testing.
+
+    The boolean columns are passed explicitly because their defaults are only
+    applied on flush, not on Python instantiation.
+    """
+    return FieldRule(
+        field_name=field_name,
+        rule_type=rule_type,
+        value=value,
+        apply_digital=apply_digital,
+        apply_physical=apply_physical,
+    )
+
+
+class AppliesToTest(unittest.TestCase):
+    """Tests for FieldRule.applies_to."""
+
+    def test_digital_only(self):
+        rule = _rule(apply_digital=True, apply_physical=False)
+        self.assertTrue(rule.applies_to(PostType.DIGITAL))
+        self.assertFalse(rule.applies_to(PostType.PHYSICAL))
+        # AUTO applies if the rule applies to either route.
+        self.assertTrue(rule.applies_to(PostType.AUTO))
+
+    def test_physical_only(self):
+        rule = _rule(apply_digital=False, apply_physical=True)
+        self.assertFalse(rule.applies_to(PostType.DIGITAL))
+        self.assertTrue(rule.applies_to(PostType.PHYSICAL))
+        self.assertTrue(rule.applies_to(PostType.AUTO))
+
+    def test_both(self):
+        rule = _rule(apply_digital=True, apply_physical=True)
+        self.assertTrue(rule.applies_to(PostType.DIGITAL))
+        self.assertTrue(rule.applies_to(PostType.PHYSICAL))
+        self.assertTrue(rule.applies_to(PostType.AUTO))
+
+    def test_neither(self):
+        rule = _rule(apply_digital=False, apply_physical=False)
+        self.assertFalse(rule.applies_to(PostType.DIGITAL))
+        self.assertFalse(rule.applies_to(PostType.PHYSICAL))
+        self.assertFalse(rule.applies_to(PostType.AUTO))
+
+
+class IsSatisfiedNotContainsTest(unittest.TestCase):
+    """Tests for FieldRule.is_satisfied with the NOT_CONTAINS rule type."""
+
+    def test_absent_field_is_satisfied(self):
+        rule = _rule(field_name="Testfelt", rule_type=RuleType.NOT_CONTAINS, value="forbudt")
+        self.assertTrue(rule.is_satisfied({"Andet Felt": "forbudt"}))
+
+    def test_value_without_substring_is_satisfied(self):
+        rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
+        self.assertTrue(rule.is_satisfied({"Testfelt": "Helt fint indhold"}))
+
+    def test_value_with_substring_violates(self):
+        rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
+        self.assertFalse(rule.is_satisfied({"Testfelt": "Dette er forbudt!"}))
+
+    def test_substring_match_is_case_insensitive(self):
+        rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
+        self.assertFalse(rule.is_satisfied({"Testfelt": "Dette er FORBUDT"}))
+        self.assertFalse(rule.is_satisfied({"Testfelt": "FoRbUdT tekst"}))
+
+    def test_empty_field_value_is_satisfied(self):
+        rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
+        self.assertTrue(rule.is_satisfied({"Testfelt": ""}))
+
+
+class IsSatisfiedRegexMatchTest(unittest.TestCase):
+    """Tests for FieldRule.is_satisfied with the REGEX_MATCH rule type."""
+
+    def test_absent_field_is_satisfied(self):
+        rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"[A-Z].*")
+        self.assertTrue(rule.is_satisfied({"Andet Felt": "abc"}))
+
+    def test_full_match_is_satisfied(self):
+        rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"\d{4}")
+        self.assertTrue(rule.is_satisfied({"Testfelt": "1234"}))
+
+    def test_no_match_violates(self):
+        rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"\d{4}")
+        self.assertFalse(rule.is_satisfied({"Testfelt": "abcd"}))
+
+    def test_partial_match_violates(self):
+        # fullmatch is required, so a value with extra characters fails.
+        rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"\d{4}")
+        self.assertFalse(rule.is_satisfied({"Testfelt": "12345"}))
+        self.assertFalse(rule.is_satisfied({"Testfelt": "x1234"}))
+
+
+class ToRowDictTest(unittest.TestCase):
+    """Tests for FieldRule.to_row_dict."""
+
+    def test_maps_fields_and_formats_booleans(self):
+        rule = _rule(field_name="Testfelt", rule_type=RuleType.REGEX_MATCH,
+                     value=r"[A-Z].*", apply_digital=True, apply_physical=False)
+        rule.id = 7
+
+        self.assertEqual(rule.to_row_dict(), {
+            "id": 7,
+            "field_name": "Testfelt",
+            "rule_type": RuleType.REGEX_MATCH.value,
+            "value": r"[A-Z].*",
+            "apply_digital": "Ja",
+            "apply_physical": "Nej",
+        })
+
+
+class ValidateFieldDataTest(unittest.TestCase):
+    """Tests for the validate_field_data send-off helper.
+
+    get_field_rules is patched so the logic can be tested without a database.
+    """
+
+    def _patch_rules(self, rules):
+        patcher = mock.patch.object(field_rules, "get_field_rules", return_value=tuple(rules))
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_no_rules_returns_none(self):
+        self._patch_rules([])
+        self.assertIsNone(field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.DIGITAL))
+
+    def test_satisfied_rule_returns_none(self):
+        self._patch_rules([_rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")])
+        self.assertIsNone(field_rules.validate_field_data({"Testfelt": "fint"}, PostType.DIGITAL))
+
+    def test_violated_rule_returns_message(self):
+        self._patch_rules([_rule(field_name="Testfelt", rule_type=RuleType.NOT_CONTAINS, value="forbudt")])
+        message = field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.DIGITAL)
+        self.assertIsNotNone(message)
+        self.assertIn("Testfelt", message)
+        self.assertIn(RuleType.NOT_CONTAINS.value, message)
+
+    def test_rule_not_applicable_to_route_is_skipped(self):
+        # A physical-only rule must not fail a letter sent digitally.
+        self._patch_rules([_rule(value="forbudt", apply_digital=False, apply_physical=True)])
+        self.assertIsNone(field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.DIGITAL))
+        # ...but it should fail when sent physically.
+        self.assertIsNotNone(field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.PHYSICAL))
+
+    def test_returns_first_violation(self):
+        self._patch_rules([
+            _rule(field_name="Felt A", rule_type=RuleType.NOT_CONTAINS, value="aaa"),
+            _rule(field_name="Felt B", rule_type=RuleType.NOT_CONTAINS, value="bbb"),
+        ])
+        message = field_rules.validate_field_data({"Felt A": "aaa", "Felt B": "bbb"}, PostType.DIGITAL)
+        self.assertIn("Felt A", message)
+        self.assertNotIn("Felt B", message)
+
+    def test_message_is_truncated_to_column_limit(self):
+        # The Letter.message column holds 100 chars; long field names must not overflow it.
+        self._patch_rules([_rule(field_name="X" * 200, rule_type=RuleType.NOT_CONTAINS, value="forbudt")])
+        message = field_rules.validate_field_data({"X" * 200: "forbudt"}, PostType.DIGITAL)
+        self.assertLessEqual(len(message), 100)
+
+
+class DatabaseCallsTest(DatabaseTestCase):
+    """Tests for the database-backed field rule functions, run against an
+    isolated in-memory database provided by DatabaseTestCase.
+    """
+
+    def test_get_field_rules_empty(self):
+        self.assertEqual(field_rules.get_field_rules(), ())
+
+    def test_create_field_rule_persists_and_assigns_id(self):
+        rule = field_rules.create_field_rule(
+            "Testfelt", RuleType.NOT_CONTAINS, "forbudt", apply_digital=True, apply_physical=False
+        )
+        self.assertIsNotNone(rule.id)
+
+        stored = field_rules.get_field_rules()
+        self.assertEqual(len(stored), 1)
+        self.assertEqual(stored[0].id, rule.id)
+        self.assertEqual(stored[0].field_name, "Testfelt")
+        self.assertEqual(stored[0].rule_type, RuleType.NOT_CONTAINS)
+        self.assertEqual(stored[0].value, "forbudt")
+        self.assertTrue(stored[0].apply_digital)
+        self.assertFalse(stored[0].apply_physical)
+
+    def test_create_multiple_field_rules(self):
+        field_rules.create_field_rule("Felt A", RuleType.NOT_CONTAINS, "aaa", True, True)
+        field_rules.create_field_rule("Felt B", RuleType.REGEX_MATCH, r"\d+", True, True)
+
+        names = sorted(rule.field_name for rule in field_rules.get_field_rules())
+        self.assertEqual(names, ["Felt A", "Felt B"])
+
+    def test_delete_field_rule(self):
+        rule = field_rules.create_field_rule("Testfelt", RuleType.NOT_CONTAINS, "forbudt", True, True)
+
+        self.assertTrue(field_rules.delete_field_rule(rule.id))
+        self.assertEqual(field_rules.get_field_rules(), ())
+
+    def test_delete_only_removes_targeted_rule(self):
+        keep = field_rules.create_field_rule("Behold", RuleType.NOT_CONTAINS, "x", True, True)
+        remove = field_rules.create_field_rule("Fjern", RuleType.NOT_CONTAINS, "y", True, True)
+
+        self.assertTrue(field_rules.delete_field_rule(remove.id))
+
+        remaining = field_rules.get_field_rules()
+        self.assertEqual([rule.id for rule in remaining], [keep.id])
+
+    def test_delete_nonexistent_returns_false(self):
+        self.assertFalse(field_rules.delete_field_rule(999))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_field_rules.py
+++ b/tests/test_field_rules.py
@@ -30,6 +30,7 @@ class AppliesToTest(unittest.TestCase):
     """Tests for FieldRule.applies_to."""
 
     def test_digital_only(self):
+        """A digital-only rule applies to DIGITAL and AUTO, but not PHYSICAL."""
         rule = _rule(apply_digital=True, apply_physical=False)
         self.assertTrue(rule.applies_to(PostType.DIGITAL))
         self.assertFalse(rule.applies_to(PostType.PHYSICAL))
@@ -37,18 +38,21 @@ class AppliesToTest(unittest.TestCase):
         self.assertTrue(rule.applies_to(PostType.AUTO))
 
     def test_physical_only(self):
+        """A physical-only rule applies to PHYSICAL and AUTO, but not DIGITAL."""
         rule = _rule(apply_digital=False, apply_physical=True)
         self.assertFalse(rule.applies_to(PostType.DIGITAL))
         self.assertTrue(rule.applies_to(PostType.PHYSICAL))
         self.assertTrue(rule.applies_to(PostType.AUTO))
 
     def test_both(self):
+        """A rule applying to both routes applies to every PostType."""
         rule = _rule(apply_digital=True, apply_physical=True)
         self.assertTrue(rule.applies_to(PostType.DIGITAL))
         self.assertTrue(rule.applies_to(PostType.PHYSICAL))
         self.assertTrue(rule.applies_to(PostType.AUTO))
 
     def test_neither(self):
+        """A rule applying to no route applies to no PostType."""
         rule = _rule(apply_digital=False, apply_physical=False)
         self.assertFalse(rule.applies_to(PostType.DIGITAL))
         self.assertFalse(rule.applies_to(PostType.PHYSICAL))
@@ -59,23 +63,28 @@ class IsSatisfiedNotContainsTest(unittest.TestCase):
     """Tests for FieldRule.is_satisfied with the NOT_CONTAINS rule type."""
 
     def test_absent_field_is_satisfied(self):
+        """A NOT_CONTAINS rule is satisfied when its field is absent from the data."""
         rule = _rule(field_name="Testfelt", rule_type=RuleType.NOT_CONTAINS, value="forbudt")
         self.assertTrue(rule.is_satisfied({"Andet Felt": "forbudt"}))
 
     def test_value_without_substring_is_satisfied(self):
+        """A value not containing the forbidden substring satisfies the rule."""
         rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
         self.assertTrue(rule.is_satisfied({"Testfelt": "Helt fint indhold"}))
 
     def test_value_with_substring_violates(self):
+        """A value containing the forbidden substring violates the rule."""
         rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
         self.assertFalse(rule.is_satisfied({"Testfelt": "Dette er forbudt!"}))
 
     def test_substring_match_is_case_insensitive(self):
+        """The NOT_CONTAINS substring check ignores case."""
         rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
         self.assertFalse(rule.is_satisfied({"Testfelt": "Dette er FORBUDT"}))
         self.assertFalse(rule.is_satisfied({"Testfelt": "FoRbUdT tekst"}))
 
     def test_empty_field_value_is_satisfied(self):
+        """An empty field value cannot contain the forbidden substring, so it is satisfied."""
         rule = _rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")
         self.assertTrue(rule.is_satisfied({"Testfelt": ""}))
 
@@ -84,18 +93,22 @@ class IsSatisfiedRegexMatchTest(unittest.TestCase):
     """Tests for FieldRule.is_satisfied with the REGEX_MATCH rule type."""
 
     def test_absent_field_is_satisfied(self):
+        """A REGEX_MATCH rule is satisfied when its field is absent from the data."""
         rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"[A-Z].*")
         self.assertTrue(rule.is_satisfied({"Andet Felt": "abc"}))
 
     def test_full_match_is_satisfied(self):
+        """A value that fully matches the pattern satisfies the rule."""
         rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"\d{4}")
         self.assertTrue(rule.is_satisfied({"Testfelt": "1234"}))
 
     def test_no_match_violates(self):
+        """A value that does not match the pattern violates the rule."""
         rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"\d{4}")
         self.assertFalse(rule.is_satisfied({"Testfelt": "abcd"}))
 
     def test_partial_match_violates(self):
+        """A partial match violates the rule; the whole value must match the pattern."""
         # fullmatch is required, so a value with extra characters fails.
         rule = _rule(rule_type=RuleType.REGEX_MATCH, value=r"\d{4}")
         self.assertFalse(rule.is_satisfied({"Testfelt": "12345"}))
@@ -106,6 +119,7 @@ class ToRowDictTest(unittest.TestCase):
     """Tests for FieldRule.to_row_dict."""
 
     def test_maps_fields_and_formats_booleans(self):
+        """to_row_dict maps all columns and renders booleans as 'Ja'/'Nej'."""
         rule = _rule(field_name="Testfelt", rule_type=RuleType.REGEX_MATCH,
                      value=r"[A-Z].*", apply_digital=True, apply_physical=False)
         rule.id = 7
@@ -132,14 +146,17 @@ class ValidateFieldDataTest(unittest.TestCase):
         patcher.start()
 
     def test_no_rules_returns_none(self):
+        """With no rules configured, validation passes (returns None)."""
         self._patch_rules([])
         self.assertIsNone(field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.DIGITAL))
 
     def test_satisfied_rule_returns_none(self):
+        """A satisfied rule produces no validation message."""
         self._patch_rules([_rule(rule_type=RuleType.NOT_CONTAINS, value="forbudt")])
         self.assertIsNone(field_rules.validate_field_data({"Testfelt": "fint"}, PostType.DIGITAL))
 
     def test_violated_rule_returns_message(self):
+        """A violated rule returns a message naming the field and rule type."""
         self._patch_rules([_rule(field_name="Testfelt", rule_type=RuleType.NOT_CONTAINS, value="forbudt")])
         message = field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.DIGITAL)
         self.assertIsNotNone(message)
@@ -147,6 +164,7 @@ class ValidateFieldDataTest(unittest.TestCase):
         self.assertIn(RuleType.NOT_CONTAINS.value, message)
 
     def test_rule_not_applicable_to_route_is_skipped(self):
+        """A rule is only enforced on routes it applies to."""
         # A physical-only rule must not fail a letter sent digitally.
         self._patch_rules([_rule(value="forbudt", apply_digital=False, apply_physical=True)])
         self.assertIsNone(field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.DIGITAL))
@@ -154,6 +172,7 @@ class ValidateFieldDataTest(unittest.TestCase):
         self.assertIsNotNone(field_rules.validate_field_data({"Testfelt": "forbudt"}, PostType.PHYSICAL))
 
     def test_returns_first_violation(self):
+        """When multiple rules are violated, only the first violation is reported."""
         self._patch_rules([
             _rule(field_name="Felt A", rule_type=RuleType.NOT_CONTAINS, value="aaa"),
             _rule(field_name="Felt B", rule_type=RuleType.NOT_CONTAINS, value="bbb"),
@@ -163,6 +182,7 @@ class ValidateFieldDataTest(unittest.TestCase):
         self.assertNotIn("Felt B", message)
 
     def test_message_is_truncated_to_column_limit(self):
+        """The validation message is truncated to fit the Letter.message column limit."""
         # The Letter.message column holds 100 chars; long field names must not overflow it.
         self._patch_rules([_rule(field_name="X" * 200, rule_type=RuleType.NOT_CONTAINS, value="forbudt")])
         message = field_rules.validate_field_data({"X" * 200: "forbudt"}, PostType.DIGITAL)
@@ -175,9 +195,11 @@ class DatabaseCallsTest(DatabaseTestCase):
     """
 
     def test_get_field_rules_empty(self):
+        """get_field_rules returns an empty tuple when no rules exist."""
         self.assertEqual(field_rules.get_field_rules(), ())
 
     def test_create_field_rule_persists_and_assigns_id(self):
+        """create_field_rule persists the rule and assigns it an id."""
         rule = field_rules.create_field_rule(
             "Testfelt", RuleType.NOT_CONTAINS, "forbudt", apply_digital=True, apply_physical=False
         )
@@ -193,6 +215,7 @@ class DatabaseCallsTest(DatabaseTestCase):
         self.assertFalse(stored[0].apply_physical)
 
     def test_create_multiple_field_rules(self):
+        """Multiple rules can be created and are all returned by get_field_rules."""
         field_rules.create_field_rule("Felt A", RuleType.NOT_CONTAINS, "aaa", True, True)
         field_rules.create_field_rule("Felt B", RuleType.REGEX_MATCH, r"\d+", True, True)
 
@@ -200,12 +223,14 @@ class DatabaseCallsTest(DatabaseTestCase):
         self.assertEqual(names, ["Felt A", "Felt B"])
 
     def test_delete_field_rule(self):
+        """delete_field_rule removes an existing rule and returns True."""
         rule = field_rules.create_field_rule("Testfelt", RuleType.NOT_CONTAINS, "forbudt", True, True)
 
         self.assertTrue(field_rules.delete_field_rule(rule.id))
         self.assertEqual(field_rules.get_field_rules(), ())
 
     def test_delete_only_removes_targeted_rule(self):
+        """delete_field_rule removes only the targeted rule, leaving others intact."""
         keep = field_rules.create_field_rule("Behold", RuleType.NOT_CONTAINS, "x", True, True)
         remove = field_rules.create_field_rule("Fjern", RuleType.NOT_CONTAINS, "y", True, True)
 
@@ -215,6 +240,7 @@ class DatabaseCallsTest(DatabaseTestCase):
         self.assertEqual([rule.id for rule in remaining], [keep.id])
 
     def test_delete_nonexistent_returns_false(self):
+        """Deleting a non-existent rule id returns False."""
         self.assertFalse(field_rules.delete_field_rule(999))
 
 


### PR DESCRIPTION
Added user defined merge field rules, where an admin can set up rules that blocks shipments if not satisfied.

In the screenshots an example rule blocks phsyical shipments if the 'postnummer' field contains '0000' or '9999'.

<img width="1099" height="694" alt="image" src="https://github.com/user-attachments/assets/736c83f3-20ed-46a4-aa9b-618d093b33dd" />
<img width="438" height="547" alt="image" src="https://github.com/user-attachments/assets/8243251c-315d-4396-b68c-130681db108b" />
<img width="1227" height="53" alt="image" src="https://github.com/user-attachments/assets/f9209996-42b5-4760-a022-6d83026b2c88" />
